### PR TITLE
update api developer key link and fix data model example image order

### DIFF
--- a/aftercareDataModel.mdx
+++ b/aftercareDataModel.mdx
@@ -43,13 +43,13 @@ We categorize and subcategorize as needed to generate a theme hierarchy for your
 - Level 1:
 
   <Frame caption="Top-level themes for responses to the question: 'How did you hear about us?'">
-    ![Tier 1](/images/categories1.png)
+    ![Tier 1](/images/categories3.png)
   </Frame>
 
 - Level 2:
 
   <Frame caption="Sub-themes for responses under the 'Tech Platforms' category">
-    ![Tier 2](/images/categories3.png)
+    ![Tier 2](/images/categories1.png)
   </Frame>
 
 - Level 3:

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -6,12 +6,12 @@ icon: "square-terminal"
 
 ## Prerequisites
 
-Grab your Aftercare API Key from the [Aftercare Developer Settings](https://surveys.getaftercare.com/developer).
+Grab your Aftercare API Key from the [Aftercare Developer Settings](https://surveys.getaftercare.com/developer/general).
 
 <Card
   title="Aftercare Developer Settings"
   icon="code"
-  href="https://surveys.getaftercare.com/developer"
+  href="https://surveys.getaftercare.com/developer/general"
 >
   Click here to create your API Key
 </Card>


### PR DESCRIPTION
https://linear.app/aftercare/issue/ENG-850/fix-api-keys-link-in-api-docs

tested locally. api key pointing to correct url now, no longer returns 404