### PR TITLE
add documentation for survey platform integrations

### DIFF
--- a/integrations.mdx
+++ b/integrations.mdx
@@ -7,7 +7,7 @@ description: "Easily integrate Aftercare into your favorite survey platform"
 
 Aftercare seamlessly integrates with your preferred survey platform, allowing you to enhance your surveys with AI-powered features. For each platform, we provide straightforward integration options to get you up and running quickly.
 
-Each platform integrations supports:
+We support various paradigms for integrating Aftercare into your survey platform:
 
 - Single followup questions
 - Multiple followup questions
@@ -16,6 +16,10 @@ Each platform integrations supports:
 Visit the platform-specific pages for detailed implementation guides and code examples.
 
 ## Supported Platforms
+
+<Tip>
+  Do not see your platform listed? [Contact us](mailto:support@getaftercare.com) to request support!
+</Tip>
 
 <CardGroup cols={2}>
   <Card title="Forsta (Decipher)" href="/integrations/forsta" />

--- a/integrations.mdx
+++ b/integrations.mdx
@@ -1,0 +1,32 @@
+---
+title: Overview
+description: "Easily integrate Aftercare into your favorite survey platform"
+---
+
+## Introduction
+
+Aftercare seamlessly integrates with your preferred survey platform, allowing you to enhance your surveys with AI-powered features. For each platform, we provide straightforward integration options to get you up and running quickly.
+
+Each platform integrations supports:
+
+- Single followup questions
+- Multiple followup questions
+- Data Quality API integration
+
+Visit the platform-specific pages for detailed implementation guides and code examples.
+
+## Supported Platforms
+
+<CardGroup cols={2}>
+  <Card title="Forsta (Decipher)" href="/integrations/forsta" />
+  <Card title="Qualtrics" href="/integrations/qualtrics" />
+  <Card title="Alchemer" href="/integrations/alchemer" />
+  <Card title="IntelliSurvey" href="">
+    {" "}
+    Coming soon{" "}
+  </Card>
+  <Card title="Voxco" href="">
+    {" "}
+    Coming soon{" "}
+  </Card>
+</CardGroup>

--- a/integrations/alchemer.mdx
+++ b/integrations/alchemer.mdx
@@ -3,11 +3,6 @@ title: "Alchemer"
 description: "Set up Aftercare with your Alchemer surveys"
 ---
 
-## Table of Contents
-
-- [Single Followup Question](#single-followup-question)
-- [Data Quality Evaluation](#data-quality-evaluation)
-
 ## Single Followup Question
 
 To add a single followup question after an open-end in Alchemer, follow these steps:
@@ -282,15 +277,5 @@ You can either:
 
 - Store these values in your survey data and export for analysis
 - Or, you can access the Aftercare platform to view and download the quality evaluations.
-
-## Best Practices
-
-1. **API Key Security:** Store your API key securely and never expose it to respondents.
-2. **Error Handling:** Always provide fallback questions if the API call fails.
-
-## Troubleshooting
-
-- If followup questions are not appearing, check your API key and webhook configuration.
-- For blank responses, verify your question and hidden value mappings.
 
 If you have any questions, please [contact our support team](mailto:support@getaftercare.com).

--- a/integrations/alchemer.mdx
+++ b/integrations/alchemer.mdx
@@ -1,0 +1,296 @@
+---
+title: "Alchemer"
+description: "Set up Aftercare with your Alchemer surveys"
+---
+
+## Table of Contents
+
+- [Single Followup Question](#single-followup-question)
+- [Data Quality Evaluation](#data-quality-evaluation)
+
+## Single Followup Question
+
+To add a single followup question after an open-end in Alchemer, follow these steps:
+
+1. **Create your open-ended question** (e.g., Q1).
+2. **Add a Hidden Value action** to store the followup question (e.g., `followup_question`).
+3. **Add a Text Entry question for the respondent's answer.**
+4. **Add a JavaScript Action** after the respondent's answer and before displaying the followup question.
+5. **Paste the following code into the JavaScript editor:**
+   - Update the `PREPPOP_MAPPINGS` array to match your hidden value question IDs and the JSON keys you want to map.
+   - Set `hiddenAnswerQID` to the Question ID of your answer field.
+   - Set `URL` and `apiKey` as needed.
+
+```javascript
+document.addEventListener("DOMContentLoaded", function () {
+  const PREPPOP_MAPPINGS = [
+    { jsonKey: "followupQuestion", qid: 20 }, // Update 20 to your hidden value QID
+  ];
+
+  const URL = "https://surveys.getaftercare.com/api/v1/followups"; // Update to your endpoint
+  const apiKey = ""; // Update to your API key
+  const hiddenAnswerQID = 27; // Update to your answer field QID
+
+  const getHiddenInputValue = (qid) => {
+    const surveyId = SGAPI.survey.surveyObject.id;
+    const pageId = SGAPI.survey.pageId;
+    const inputId = `sgE-${surveyId}-${pageId}-${qid}-element`;
+    const input = document.getElementById(inputId);
+    return input ? input.value : "";
+  };
+
+  const getElemByQid = (qid, section = "element") => {
+    const id = `sgE-${SGAPI.survey.surveyObject.id}-${SGAPI.survey.pageId}-${qid}-${section}`;
+    return document.getElementById(id);
+  };
+
+  const hidePageContent = () => {
+    const content = document.querySelector(".sg-page-content");
+    if (content) content.style.display = "none";
+  };
+
+  const prepop = (mappings, data) => {
+    mappings.forEach(({ jsonKey, qid }) => {
+      const val = data[jsonKey];
+      const elem = getElemByQid(qid);
+      if (elem) elem.value = val || "";
+    });
+  };
+
+  const clickNextButton = () => {
+    const nextButton =
+      document.querySelector("#sg_NextButton") ||
+      document.querySelector("#sg_SubmitButton");
+    if (nextButton) {
+      nextButton.disabled = false;
+      nextButton.style.display = "block";
+      try {
+        nextButton.click();
+        setTimeout(() => {
+          const clickEvent = new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+          });
+          nextButton.dispatchEvent(clickEvent);
+        }, 300);
+      } catch (e) {
+        console.error("Error clicking button:", e);
+      }
+    } else {
+      setTimeout(clickNextButton, 200);
+    }
+  };
+
+  const executeMain = () => {
+    try {
+      const answer = getHiddenInputValue(hiddenAnswerQID);
+      const payload = {
+        question: "Question", // replace with the text of the topic question
+        answer: answer,
+        guidanceBehavior: "Verbose",
+      };
+      hidePageContent();
+      fetch(URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Aftercare-Key": apiKey,
+        },
+        body: JSON.stringify(payload),
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          console.log("API response:", data);
+          prepop(PREPPOP_MAPPINGS, data);
+          setTimeout(clickNextButton, 200);
+        })
+        .catch((err) => {
+          console.error("API error:", err);
+          setTimeout(clickNextButton, 500);
+        });
+    } catch (e) {
+      console.error("Main execution error:", e);
+    }
+  };
+
+  executeMain();
+});
+```
+
+## Data Quality Evaluation
+
+To evaluate response quality in Alchemer using JavaScript, follow these steps:
+
+1. **Add a Hidden Value action** for each field you want to store from the API response (e.g., `qualityScore`, `isFlagged`).
+2. **Add a Text Entry question for the respondent's answer.**
+3. **Add a JavaScript Action** after the answer.
+4. **Paste the following code into the JavaScript editor:**
+   - Update the `mappings` array in `CONFIG` to match your hidden value question IDs and the JSON keys you want to map.
+   - Set `hiddenAnswerQID` to the Question ID of your answer field.
+   - Set `api.url` and `api.key` as needed.
+
+```javascript
+document.addEventListener("DOMContentLoaded", function () {
+  // Configuration constants
+  const CONFIG = {
+    mappings: [
+      { jsonKey: "qualityScore", qid: 34 },
+      { jsonKey: "isFlagged", qid: 35 },
+    ],
+    api: {
+      url: "https://surveys.getaftercare.com/api/v1/data-quality/evaluate", // Update to your endpoint
+      key: "", // Update to your API key
+    },
+    hiddenAnswerQID: 27, // Update to your answer field QID
+    retryDelay: 200,
+    buttonClickDelay: 300,
+  };
+
+  // Helper functions
+  const helpers = {
+    getElementId: (qid, section = "element") =>
+      `sgE-${SGAPI.survey.surveyObject.id}-${SGAPI.survey.pageId}-${qid}-${section}`,
+
+    getElement: (qid, section = "element") =>
+      document.getElementById(helpers.getElementId(qid, section)),
+
+    getHiddenInputValue: (qid) => {
+      const input = helpers.getElement(qid);
+      return input ? input.value : "";
+    },
+
+    hidePageContent: () => {
+      const content = document.querySelector(".sg-page-content");
+      if (content) content.style.display = "none";
+    },
+
+    prepopFields: (mappings, data) => {
+      mappings.forEach(({ jsonKey, qid }) => {
+        const value = data[jsonKey];
+        const element = helpers.getElement(qid);
+        if (element) element.value = value || "";
+      });
+    },
+
+    clickNextButton: () => {
+      const nextButton =
+        document.querySelector("#sg_NextButton") ||
+        document.querySelector("#sg_SubmitButton");
+
+      if (!nextButton) {
+        return setTimeout(helpers.clickNextButton, CONFIG.retryDelay);
+      }
+
+      nextButton.disabled = false;
+      nextButton.style.display = "block";
+
+      try {
+        // Try native click first
+        nextButton.click();
+
+        // Fallback to dispatching click event
+        setTimeout(() => {
+          const clickEvent = new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+          });
+          nextButton.dispatchEvent(clickEvent);
+        }, CONFIG.buttonClickDelay);
+      } catch (error) {
+        console.error("Failed to click button:", error);
+      }
+    },
+
+    // Save data to localStorage
+    saveData: (data) => {
+      try {
+        localStorage.setItem(
+          "aftercareDataQualityResults",
+          JSON.stringify(data)
+        );
+        console.log("Data saved successfully to localStorage");
+      } catch (error) {
+        console.error("Failed to save data to localStorage:", error);
+      }
+    },
+  };
+
+  // Main function
+  const main = async () => {
+    try {
+      // Get the answer value
+      const answer = helpers.getHiddenInputValue(CONFIG.hiddenAnswerQID);
+
+      // Prepare the API payload
+      const payload = {
+        surveyName: "Response Quality Evaluation",
+        surveyEntries: [
+          {
+            question: "Question", // Replace this with the text of the question
+            answer: answer,
+          },
+        ],
+      };
+
+      // Hide the page content while processing
+      helpers.hidePageContent();
+
+      try {
+        // Make the API request
+        const response = await fetch(CONFIG.api.url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Aftercare-Key": CONFIG.api.key,
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          throw new Error(`API returned status ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        // Save the API response data
+        helpers.saveData(data);
+
+        // Populate the form fields with API response
+        helpers.prepopFields(CONFIG.mappings, data);
+
+        // Proceed to next page
+        setTimeout(helpers.clickNextButton, CONFIG.retryDelay);
+      } catch (apiError) {
+        console.error("API request failed:", apiError);
+        setTimeout(helpers.clickNextButton, CONFIG.retryDelay * 2.5);
+      }
+    } catch (error) {
+      console.error("Main execution error:", error);
+      // Still try to proceed to next page on error
+      setTimeout(helpers.clickNextButton, CONFIG.retryDelay);
+    }
+  };
+
+  // Start execution
+  main();
+});
+```
+
+You can either:
+
+- Store these values in your survey data and export for analysis
+- Or, you can access the Aftercare platform to view and download the quality evaluations.
+
+## Best Practices
+
+1. **API Key Security:** Store your API key securely and never expose it to respondents.
+2. **Error Handling:** Always provide fallback questions if the API call fails.
+
+## Troubleshooting
+
+- If followup questions are not appearing, check your API key and webhook configuration.
+- For blank responses, verify your question and hidden value mappings.
+
+If you have any questions, please [contact our support team](mailto:support@getaftercare.com).

--- a/integrations/forsta.mdx
+++ b/integrations/forsta.mdx
@@ -1,0 +1,399 @@
+---
+title: "Forsta (Decipher)"
+description: "Set up Aftercare with your Forsta (Decipher) surveys"
+---
+
+- [Single Followup Question](#single-followup-question)
+- [Multiple Followup Questions](#multiple-followup-questions)
+- [Data Quality Evaluation](#data-quality-evaluation)
+
+## Single Followup Question
+
+To add a single followup question for an open-end, follow these steps:
+
+First, initialize the API request data in an `<exec>` block. This sets up the headers and prepares the request body:
+
+```decipher
+<exec>
+# Set up API headers with your Aftercare API key
+p.api_headers = {
+    "X-Aftercare-Key": "<AFTERCARE API KEY>",
+    "Content-Type": "application/json"
+}
+
+# Get the question and response from your survey
+question = TopicQuestion.title  # replace with your topic question variable
+response = TopicQuestion.val  # replace with your topic question variable
+
+# Prepare the API request body
+p.api_data = '{
+    "question": "' + question + '",
+    "answer": "' + response + '",
+    "surveyName": "<Your Survey Name>",  # optional
+    "surveyDescription": "<Description of your survey>",  # optional
+    "questionContext": "<What you want to learn from the respondent>",  # optional
+    "guidanceBehavior": "Succinct"  # optional, defaults to "Succinct"
+}'
+</exec>
+```
+
+Next, make the API request using the `<logic>` block. This sends the request to Aftercare's API and waits for the response:
+
+```decipher
+<logic
+    label="followup_request"
+    api:data="p.api_data"
+    api:headers="p.api_headers"
+    api:method="POST"
+    api:url="https://surveys.getaftercare.com/api/v1/followups"
+    sst="0"
+    uses="api.1"
+/>
+```
+
+After receiving the response, process it in another `<exec>` block. This handles both successful responses and errors:
+
+```decipher
+<exec>
+# Check if the API call was successful
+if followup_request.status == 200:
+    # Extract the followup question from the response
+    p.followup_question = followup_request.r["followupQuestion"]
+else:
+    # Use a fallback question if the API call fails
+    p.followup_question = "Is there anything more you'd like to add?"
+</exec>
+```
+
+Now, display the followup question to the respondent using a `<textarea>` element:
+
+```decipher
+<suspend />
+<textarea
+    label="FollowupQuestion"
+    height="10"
+    optional="0"
+    width="50">
+    <title>${p.followup_question}</title>
+</textarea>
+```
+
+Finally, store the followup question in a variable for data export and reporting:
+
+```decipher
+<suspend />
+<exec>FOLLOWUP_Q_TEXT.val = p.followup_question</exec>
+<suspend />
+<text
+    label="FOLLOWUP_Q_TEXT"
+    optional="0"
+    size="25"
+    where="execute,survey,report">
+    <title>FOLLOWUP_Q_TEXT</title>
+</text>
+<suspend />
+```
+
+## Multiple Followup Questions
+
+To implement multiple followup questions that continue until the AI determines no more questions are needed, follow these steps:
+
+First, initialize the API request data and tracking variables. This sets up the headers and prepares the variables we'll need to track multiple followups:
+
+```decipher
+<exec>
+# Set up API headers with your Aftercare API key
+p.api_headers = {
+    "X-Aftercare-Key": "<AFTERCARE API KEY>",
+    "Content-Type": "application/json"
+}
+
+# Get the initial question and response
+p.question = TopicQuestion.title  # replace with your topic question variable
+p.initial_response = TopicQuestion.val  # replace with your topic question variable
+
+# Initialize tracking variables
+p.max_followups = 10  # replace with number of maximum desired follwups for one question
+p.current_followup = 1
+p.total_followups_shown = 0
+
+# Create arrays to store all followup questions and responses
+p.followup_questions = []
+p.followup_responses = []
+
+# Initialize thread ID variable
+p.thread_id = None
+</exec>
+```
+
+Next, set up the loop structure that will handle multiple followups. This includes the loop label and the initial check for maximum followups:
+
+```decipher
+# --- START THE FOLLOWUP LOOP ---
+
+<label name="GENERATE_FOLLOWUP" />
+
+# Check if we've reached the maximum number of followups
+<exec>
+p.continue_followup = p.current_followup <= p.max_followups
+</exec>
+
+<goto condition="!p.continue_followup" label="END_FOLLOWUPS" />
+```
+
+Now, prepare the API request. For the first followup, we use the initial question and response. For subsequent followups, we use the previous followup question and response:
+
+```decipher
+<exec>
+if p.current_followup == 1:
+    # First followup uses initial question and response
+    p.prev_question = p.question
+    p.prev_response = p.initial_response
+    # First followup doesn't need a thread ID
+    p.api_data = '{
+        "question": "' + p.prev_question + '",
+        "answer": "' + p.prev_response + '",
+        "surveyName": "<Your Survey Name>",  # optional
+        "surveyDescription": "<Description of your survey>",  # optional
+        "questionContext": "<What you want to learn from the respondent>",  # optional
+        "guidanceBehavior": "Succinct"  # optional, defaults to "Succinct"
+    }'
+else:
+    # Subsequent followups use the previous followup question and response
+    p.prev_question = p.followup_questions[p.current_followup - 2]  # Arrays are 0-indexed
+    p.prev_response = p.followup_responses[p.current_followup - 2]
+    # Include thread ID for followups after the first one
+    p.api_data = '{
+        "question": "' + p.prev_question + '",
+        "answer": "' + p.prev_response + '",
+        "surveyName": "<Your Survey Name>",  # optional
+        "surveyDescription": "<Description of your survey>",  # optional
+        "questionContext": "<What you want to learn from the respondent>",  # optional
+        "guidanceBehavior": "Succinct",  # optional, defaults to "Succinct"
+        "threadId": "' + p.thread_id + '"  # required for followups after the first one
+    }'
+</exec>
+```
+
+Make the API call to get the followup question:
+
+```decipher
+<logic
+    label="followup_request"
+    api:data="p.api_data"
+    api:headers="p.api_headers"
+    api:method="POST"
+    api:url="https://surveys.getaftercare.com/api/v1/followups"
+    sst="0"
+    uses="api.1"
+/>
+```
+
+Process the API response and check if we should continue with followups:
+
+```decipher
+<exec>
+# Check if the API call was successful
+if followup_request.status == 200:
+    # Extract the followup question from the response
+    p.current_followup_text = followup_request.r["followupQuestion"]
+
+    # For the first followup, store the thread ID for subsequent followups
+    if p.current_followup == 1:
+        p.thread_id = followup_request.r["threadId"]
+else:
+    # Use a fallback question if the API call fails
+    p.current_followup_text = ""
+
+# Check if the followup text is blank, which means we should stop
+p.is_blank_followup = p.current_followup_text.strip() == ""
+
+# Store the current followup text in a variable that matches the current followup number
+set("FOLLOWUP_TEXT_" + str(p.current_followup), p.current_followup_text)
+</exec>
+
+# Skip to the end if we got a blank followup
+<goto condition="p.is_blank_followup" label="END_FOLLOWUPS" />
+```
+
+Display the followup question to the respondent and get their response:
+
+```decipher
+<textarea
+    label="FollowupQuestion_${p.current_followup}"
+    height="10"
+    optional="1"
+    width="50"
+>
+    <title>${p.current_followup_text}</title>
+</textarea>
+
+<suspend />
+
+<exec>
+# Get the response
+p.current_response = eval("FollowupQuestion_" + str(p.current_followup) + ".unsafe_val")
+
+# Check if response is blank
+p.is_blank_response = p.current_response.strip() == ""
+
+# Store the followup question and response in our arrays
+p.followup_questions.append(p.current_followup_text)
+p.followup_responses.append(p.current_response)
+
+# Increment the followup counter and total followups shown
+p.total_followups_shown = p.current_followup
+p.current_followup += 1
+
+# Store the response in a variable
+set("FOLLOWUP_RESPONSE_" + str(p.total_followups_shown), p.current_response)
+</exec>
+```
+
+Check if we should continue with more followups:
+
+```decipher
+# If the response was blank, end the followups
+<goto condition="p.is_blank_response" label="END_FOLLOWUPS" />
+
+# Otherwise, continue with the next followup
+<goto label="GENERATE_FOLLOWUP" />
+```
+
+Finally, set up the end of the followup section and store all responses for reporting:
+
+```decipher
+# --- END OF FOLLOWUPS ---
+
+<label name="END_FOLLOWUPS" />
+
+# Store the total number of followups shown
+<exec>TOTAL_FOLLOWUPS.val = p.total_followups_shown</exec>
+
+<text
+    label="TOTAL_FOLLOWUPS"
+    optional="0"
+    size="5"
+    where="execute,survey,report"
+>
+    <title>Total number of followups shown</title>
+</text>
+
+<exec>
+# Store responses in their respective variables
+for i in range(p.total_followups_shown):
+    set("FOLLOWUP_RESPONSE_" + str(i + 1), p.followup_responses[i])
+</exec>
+```
+
+## Data Quality Evaluation
+
+To evaluate the quality of responses using Aftercare's Data Quality API, follow these steps:
+
+First, initialize the API request data in an `<exec>` block. This sets up the headers and prepares the request body:
+
+```decipher
+<exec>
+# Set up API headers with your Aftercare API key
+p.api_headers = {
+    "X-Aftercare-Key": "<AFTERCARE API KEY>",
+    "Content-Type": "application/json"
+}
+
+# Get the questions and responses from your survey. You can evaluate multiple answers from the respondent at once
+p.survey_entries = []
+p.survey_entries.append({
+    "question": TopicQuestion1.title,  # The question that was asked to the respondent
+    "answer": TopicQuestion1.val,      # The answer to the question provided by the respondent
+    "questionIdentifier": "q1",        # Optional unique identifier for the question
+})
+p.survey_entries.append({
+    "question": TopicQuestion2.title,
+    "answer": TopicQuestion2.val,
+    "questionIdentifier": "q2",
+})
+
+# Prepare the API request body
+p.api_data = '{
+    "surveyName": "<Your Survey Name>",  # The name of the survey as it will appear in the Aftercare platform
+    "surveyDescription": "<Description of your survey>",  # Description of the survey purpose and background
+    "surveyIdentifier": "survey_123",  # Optional unique identifier for the survey
+    "responseIdentifier": "resp_123",  # Optional unique identifier for a respondent's entire response
+    "surveyEntries": [
+        {
+            "question": "' + p.survey_entries[0]["question"] + '",
+            "answer": "' + p.survey_entries[0]["answer"] + '",
+            "questionIdentifier": "' + p.survey_entries[0]["questionIdentifier"] + '",
+        },
+        {
+            "question": "' + p.survey_entries[1]["question"] + '",
+            "answer": "' + p.survey_entries[1]["answer"] + '",
+            "questionIdentifier": "' + p.survey_entries[1]["questionIdentifier"] + '",
+        }
+    ]
+}'
+</exec>
+```
+
+Next, make the API request using the `<logic>` block. This sends the request to Aftercare's Data Quality API and waits for the response:
+
+```decipher
+<logic
+    label="quality_request"
+    api:data="p.api_data"
+    api:headers="p.api_headers"
+    api:method="POST"
+    api:url="https://surveys.getaftercare.com/api/v1/data-quality/evaluate"
+    sst="0"
+    uses="api.1"
+/>
+```
+
+After receiving the response, process it in another `<exec>` block. This handles both successful responses and errors:
+
+```decipher
+<exec>
+# Check if the API call was successful
+if quality_request.status == 200:
+    # Extract the overall quality metrics
+    p.has_issues = quality_request.r["hasIssues"]  # Whether any issues were detected
+    p.num_issues = quality_request.r["numIssues"]  # Number of quality issues detected across all entries
+    p.quality_score = quality_request.r["qualityScore"]  # Overall quality score (0-100)
+
+    # Process individual evaluations
+    p.evaluations = quality_request.r["evaluations"]
+    for i, evaluation in enumerate(p.evaluations):
+        # Each evaluation contains:
+        # - surveyEntry: The original question and answer
+        # - numIssues: Number of issues detected for this entry
+        # - qualityScore: Quality score for this entry (0-100)
+        # - qualityIssueChecks: Detailed quality checks
+        # - hasIssues: Whether any issues were detected
+
+        # Store the quality score for this entry
+        set("QUALITY_SCORE_" + str(i + 1), evaluation["qualityScore"])
+
+        # Store the number of issues for this entry
+        set("NUM_ISSUES_" + str(i + 1), evaluation["numIssues"])
+
+        # Store whether issues were detected
+        set("HAS_ISSUES_" + str(i + 1), evaluation["hasIssues"])
+</exec>
+```
+
+You can then either:
+
+1. Store these values in your survey data for analysis
+2. Access the Aftercare platform to view and download the quality evaluations
+
+## Best Practices
+
+1. **API Key Security**: Store your API key in a secure location and never expose it in client-side code.
+2. **Error Handling**: Always implement fallback questions in case the API call fails.
+
+## Troubleshooting
+
+- If you're not receiving followup questions, check your API key and network connectivity.
+- For blank responses, verify that your question and response variables are correctly named.
+
+Need help? [Contact our support team](mailto:anand@getaftercare.com)

--- a/integrations/forsta.mdx
+++ b/integrations/forsta.mdx
@@ -3,10 +3,6 @@ title: "Forsta (Decipher)"
 description: "Set up Aftercare with your Forsta (Decipher) surveys"
 ---
 
-- [Single Followup Question](#single-followup-question)
-- [Multiple Followup Questions](#multiple-followup-questions)
-- [Data Quality Evaluation](#data-quality-evaluation)
-
 ## Single Followup Question
 
 To add a single followup question for an open-end, follow these steps:
@@ -385,15 +381,5 @@ You can then either:
 
 1. Store these values in your survey data for analysis
 2. Access the Aftercare platform to view and download the quality evaluations
-
-## Best Practices
-
-1. **API Key Security**: Store your API key in a secure location and never expose it in client-side code.
-2. **Error Handling**: Always implement fallback questions in case the API call fails.
-
-## Troubleshooting
-
-- If you're not receiving followup questions, check your API key and network connectivity.
-- For blank responses, verify that your question and response variables are correctly named.
 
 Need help? [Contact our support team](mailto:anand@getaftercare.com)

--- a/integrations/qualtrics.mdx
+++ b/integrations/qualtrics.mdx
@@ -1,0 +1,350 @@
+---
+title: "Qualtrics"
+description: "Set up Aftercare with your Qualtrics surveys"
+---
+
+- [Single Followup Question](#single-followup-question)
+- [Multiple Followup Questions](#multiple-followup-questions)
+- [Data Quality Evaluation](#data-quality-evaluation)
+
+## Single Followup Question
+
+For single followup questions, you can make use of the [Web Service](https://www.qualtrics.com/support/survey-platform/survey-module/survey-flow/advanced-elements/web-service/) feature in Qualtrics.
+
+### Setup Instructions
+
+1. Create two Text Entry questions and place them in different blocks:
+
+   - First question: Your topic question
+   - Second question: The followup question
+
+2. Set up the followup question text to use a piping reference:
+
+   ```
+   ${e://Field/followup_question}
+   ```
+
+3. Between the blocks, create a Web Service with this configuration:
+
+```json
+URL: https://surveys.getaftercare.com/api/v1/followups
+Method: POST
+Body Parameters: application/json
+  - question = "${q://QID1/QuestionText}" # replace "QID1" with your Qualtrics question identifier
+  - answer = "${q://QID1/ChoiceTextEntryValue}" # replace "QID1" with your Qualtrics question identifier
+  - questionContext = <what you want to learn from the respondent> # optional
+Custom Headers:
+  - X-Aftercare-Key = sk_wcmaphuvCF9YL3M3gfzWuobkGkdXMTyJ
+Set Embedded Data
+  - followup_question = followupQuestion
+```
+
+## Multiple Followup Questions
+
+For multiple followup questions, you can utilize Javascript combined with the Loop & Merge feature.
+
+### 1. Set Up Your Survey Structure
+
+- Create a survey with at least two blocks:
+  - **Topic Question Block:** Contains your primary open-ended question.
+  - **Followup Question Block:** Will display each followup question.
+
+### 2. Add Embedded Data Fields
+
+In the Survey Flow, add the following Embedded Data fields to track the conversation:
+
+- `TopicQuestion` (stores the original question text)
+- `TopicResponse` (stores the original question response)
+- `LastQuestion` (stores the most recent question asked)
+- `LastResponse` (stores the most recent response given)
+- `FollowupText` (stores the current followup question from API)
+- `ContinueFollowups` (1 = continue loop, 0 = end loop)
+- `FollowupCount` (tracks how many followup questions have been asked)
+
+### 3. Create a Loop & Merge Block
+
+- Set up Loop & Merge on the Followup Question Block.
+- Use a hidden numeric question to control the loop count (see below for code).
+
+### 4. Add JavaScript to the Prime Question
+
+Add the following JavaScript to your topic question to initialize variables and make the first API call:
+
+```javascript
+Qualtrics.SurveyEngine.addOnPageSubmit(function () {
+  // Get the question text and response
+  var questionText = this.getQuestionInfo().QuestionText;
+  var response = this.getTextValue();
+
+  // Remove any HTML tags from the text
+  questionText = questionText.replace(/<[^>]*>/g, "");
+
+  // Store in embedded data
+  Qualtrics.SurveyEngine.setEmbeddedData("TopicQuestion", questionText);
+  Qualtrics.SurveyEngine.setEmbeddedData("TopicResponse", response);
+
+  // Initialize tracking variables
+  Qualtrics.SurveyEngine.setEmbeddedData("LastQuestion", questionText);
+  Qualtrics.SurveyEngine.setEmbeddedData("LastResponse", response);
+  Qualtrics.SurveyEngine.setEmbeddedData("ContinueFollowups", 1); // Start with asking followups enabled
+  Qualtrics.SurveyEngine.setEmbeddedData("FollowupCount", 0); // No followups asked yet
+
+  // Make API call to get the first followup question
+  makeFollowupAPICall(questionText, response);
+});
+```
+
+### 5. Define the API Call Function
+
+This function makes the API call to get the next followup question from Aftercare:
+
+```javascript
+function makeFollowupAPICall(question, response) {
+  // API call parameters
+  var apiUrl = "https://surveys.getaftercare.com/api/v1/followups";
+  var apiKey = "REPLACE_WITH_YOUR_API_KEY";
+  var langId = "en"; // or whatever language you need
+
+  // Prepare API data
+  var apiData = {
+    question: question,
+    answer: response,
+    surveyName: "<Your Survey Name>", // optional
+    surveyDescription: "<Description of your survey>", // optional
+    questionContext: "<What you want to learn from the respondent>", // optional
+    guidanceBehavior: "Succinct", // optional, defaults to "Succinct"
+  };
+
+  // Make the AJAX call
+  jQuery.ajax({
+    url: apiUrl,
+    type: "POST",
+    data: JSON.stringify(apiData),
+    contentType: "application/json",
+    headers: {
+      "X-Aftercare-Key": "<AFTERCARE API KEY>",
+      "Content-Type": "application/json",
+    },
+    success: function (data) {
+      var followupText = data.followupQuestion || "";
+
+      // Store the followup text
+      Qualtrics.SurveyEngine.setEmbeddedData("FollowupText", followupText);
+
+      // Determine if we should continue looping or not
+      if (followupText.trim() === "") {
+        // Stop looping if we got a blank followup
+        Qualtrics.SurveyEngine.setEmbeddedData("ContinueFollowups", 0);
+        setLoopCountToZero();
+      } else {
+        // Continue looping if we got a valid followup
+        Qualtrics.SurveyEngine.setEmbeddedData("ContinueFollowups", 1);
+        setLoopCountToOne();
+      }
+    },
+    error: function () {
+      // Use fallback text on error
+      var fallbackText = "Is there anything more you'd like to add?";
+      Qualtrics.SurveyEngine.setEmbeddedData("FollowupText", fallbackText);
+      Qualtrics.SurveyEngine.setEmbeddedData("ContinueFollowups", 1);
+      setLoopCountToOne();
+    },
+  });
+}
+```
+
+### 6. Control the Loop Count with a Hidden Numeric Question
+
+Add this JavaScript to your hidden numeric question to hide it and set a default value:
+
+```javascript
+Qualtrics.SurveyEngine.addOnload(function () {
+  // Hide this question completely
+  this.hideChoices();
+  this.hideLabel();
+  jQuery("#" + this.questionId).hide();
+
+  // Set a default value
+  this.setChoiceValue(1);
+});
+```
+
+Define helper functions to set the loop count:
+
+```javascript
+function setLoopCountToZero() {
+  // Replace QID1 with the ID of your hidden numeric question
+  jQuery("#QID1").val(0);
+  jQuery("#QID1").trigger("keyup");
+}
+
+function setLoopCountToOne() {
+  // Replace QID1 with the ID of your hidden numeric question
+  jQuery("#QID1").val(1);
+  jQuery("#QID1").trigger("keyup");
+}
+```
+
+### 7. Add JavaScript to the Followup Question in the Loop & Merge Block
+
+This code displays the followup question and determines whether to continue asking followups:
+
+```javascript
+Qualtrics.SurveyEngine.addOnload(function () {
+  var self = this;
+
+  // On the first loop, increment the followup count
+  var currentLoopNumber = "${lm://CurrentLoopNumber}";
+  if (currentLoopNumber === "1") {
+    // Get current followup count and increment it
+    var followupCount = parseInt("${e://Field/FollowupCount}") || 0;
+    followupCount++;
+    Qualtrics.SurveyEngine.setEmbeddedData("FollowupCount", followupCount);
+  }
+
+  // Check if we should continue asking followups
+  var continueProbing = "${e://Field/ContinueFollowups}" === "1";
+  if (!continueProbing) {
+    // Skip to end of survey or next block by clicking the Next button
+    self.clickNextButton();
+    return;
+  }
+
+  // Get the followup text from embedded data
+  var followupText = "${e://Field/FollowupText}";
+
+  // Display the followup text as the question text
+  if (followupText && followupText.trim() !== "") {
+    self.questionContainer.find(".QuestionText").html(followupText);
+  }
+});
+```
+
+When the respondent answers the followup question, this code determines whether to continue or stop:
+
+```javascript
+Qualtrics.SurveyEngine.addOnPageSubmit(function () {
+  // Get the response
+  var response = this.getTextValue();
+
+  // If response is blank, stop asking followups
+  if (!response || response.trim() === "") {
+    Qualtrics.SurveyEngine.setEmbeddedData("ContinueFollowups", 0);
+  } else {
+    // Save this as the last response
+    Qualtrics.SurveyEngine.setEmbeddedData("LastResponse", response);
+
+    // Get the last question
+    var lastQuestion = "${e://Field/FollowupText}";
+    Qualtrics.SurveyEngine.setEmbeddedData("LastQuestion", lastQuestion);
+
+    // Make API call to get the next followup
+    makeFollowupAPICall(lastQuestion, response);
+  }
+});
+```
+
+### 8. (Optional) Store All Followup Questions and Responses
+
+If you want to store all followup questions and responses for later analysis, add this code to the followup question's `addOnPageSubmit` function:
+
+```javascript
+// Get current followup count
+var followupCount = parseInt("${e://Field/FollowupCount}") || 0;
+
+// Store this followup question and response
+var storedFollowupQuestions = "${e://Field/StoredFollowupQuestions}" || "";
+var storedFollowupResponses = "${e://Field/StoredFollowupResponses}" || "";
+
+// Add delimiter only if we already have stored data
+if (storedFollowupQuestions !== "") {
+  storedFollowupQuestions += "||";
+  storedFollowupResponses += "||";
+}
+
+// Add new data
+storedFollowupQuestions += followupText;
+storedFollowupResponses += response;
+
+// Save to embedded data
+Qualtrics.SurveyEngine.setEmbeddedData(
+  "StoredFollowupQuestions",
+  storedFollowupQuestions
+);
+Qualtrics.SurveyEngine.setEmbeddedData(
+  "StoredFollowupResponses",
+  storedFollowupResponses
+);
+```
+
+# Data Quality Evaluation
+
+To evaluate the quality of responses using Aftercare's Data Quality API in Qualtrics, follow these steps:
+
+### 1. Prepare Your Survey Data
+
+- Identify the questions and responses you want to evaluate for quality. For example, you might want to evaluate all open-ended responses in your survey for each respondent.
+
+### 2. Add a Web Service Element in Survey Flow
+
+- Insert a Web Service element after the question you want to evaluate or at the end of the survey.
+- Configure the Web Service as follows:
+
+- **URL:** [https://surveys.getaftercare.com/api/v1/data-quality/evaluate](https://surveys.getaftercare.com/api/v1/data-quality/evaluate)
+- **Method:** POST
+- **Body Parameters:** (Content-Type: application/json)
+
+  Example body (replace QID1, QID2, etc. with your actual Qualtrics question IDs):
+
+  ```json
+  {
+    "surveyName": "<Your Survey Name>",
+    "surveyDescription": "<Description of your survey>",
+    "surveyIdentifier": "survey_123", // optional
+    "responseIdentifier": "resp_123", // optional
+    "surveyEntries": [
+      {
+        "question": "${q://QID1/QuestionText}",
+        "answer": "${q://QID1/TextEntry}",
+        "questionIdentifier": "QID1" // optional
+      },
+      {
+        "question": "${q://QID2/QuestionText}",
+        "answer": "${q://QID2/TextEntry}",
+        "questionIdentifier": "QID2" // optional
+      }
+    ]
+  }
+  ```
+
+- **Custom Headers:**
+  - `X-Aftercare-Key`: `<AFTERCARE API KEY>`
+  - `Content-Type`: `application/json`
+
+### 3. Set Embedded Data
+
+- In the Web Service element, set embedded data fields to store the results from the API response. For example:
+  - `qualityScore` = qualityScore
+  - `numIssues` = numIssues
+  - `hasIssues` = hasIssues
+  - You can also set embedded data for each entry in `evaluations` if you want to track per-question quality.
+
+### 4. Use the Results
+
+You can either:
+
+- Store these values in your survey data and export for analysis
+- Or, you can access the Aftercare platform to view and download the quality evaluations.
+
+## Best Practices
+
+1. **API Key Security**: Store your API key in a secure location and never expose it in client-side code.
+2. **Error Handling**: Always implement fallback questions in case the API call fails.
+
+## Troubleshooting
+
+- If you're not receiving followup questions, check your API key and network connectivity.
+- For blank responses, verify that your question and response variables are correctly named.
+- Make sure your Web Service is properly configured with the correct headers and parameters.
+
+Need help? [Contact our support team](mailto:support@getaftercare.com)

--- a/integrations/qualtrics.mdx
+++ b/integrations/qualtrics.mdx
@@ -3,10 +3,6 @@ title: "Qualtrics"
 description: "Set up Aftercare with your Qualtrics surveys"
 ---
 
-- [Single Followup Question](#single-followup-question)
-- [Multiple Followup Questions](#multiple-followup-questions)
-- [Data Quality Evaluation](#data-quality-evaluation)
-
 ## Single Followup Question
 
 For single followup questions, you can make use of the [Web Service](https://www.qualtrics.com/support/survey-platform/survey-module/survey-flow/advanced-elements/web-service/) feature in Qualtrics.
@@ -335,16 +331,5 @@ You can either:
 
 - Store these values in your survey data and export for analysis
 - Or, you can access the Aftercare platform to view and download the quality evaluations.
-
-## Best Practices
-
-1. **API Key Security**: Store your API key in a secure location and never expose it in client-side code.
-2. **Error Handling**: Always implement fallback questions in case the API call fails.
-
-## Troubleshooting
-
-- If you're not receiving followup questions, check your API key and network connectivity.
-- For blank responses, verify that your question and response variables are correctly named.
-- Make sure your Web Service is properly configured with the correct headers and parameters.
 
 Need help? [Contact our support team](mailto:support@getaftercare.com)

--- a/mint.json
+++ b/mint.json
@@ -49,7 +49,17 @@
       "pages": [
         "introduction",
         "aftercareDataModel",
-        "languages"
+        "languages",
+        {
+          "group": "Integrations",
+          "icon": "plug",
+          "pages": [
+            "integrations",
+            "integrations/forsta",
+            "integrations/qualtrics",
+            "integrations/alchemer"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
Currently adds integration code examples for Decipher, Qualtrics, and Alchemer.

Will need to be refined over time as we do more but I think this is a good starting point.

Integrations Page (updated):
![Screenshot 2025-05-22 at 10 24 22 AM](https://github.com/user-attachments/assets/0884c10b-ef28-404d-97bf-2e9f5df6c3ee)




The Single Followup Question and Data Quality Evaluations *should* all be working. The Multiple Followup Questions haven't yet been verified